### PR TITLE
Updated README details on Shopify

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Import tool for outside apps into OpenBazaar 2.0.
 * Titles will be truncated to 140 characters
 * Categories will be truncated to 40
 
+### Shopify
+
+* Not currently working due to Shopify's admin panel being incompatible with Electron's Chrome build 
+
 ### eBay 
 
 * Not working yet


### PR DESCRIPTION
 I updated the docs to say that Shopify is currently not working.

Shopify updated their admin panel to say that they only allow the "latest two versions of all browsers" . The most recent update to Electron is using a Chrome build 4 versions behind the current release. 

Image below shows the error message Shopify shows with the most updated Electron version (v.3.0.5 at the time of writing this)

![09c016d8436e0e65bf538425436ed989](https://user-images.githubusercontent.com/15466020/47300307-c0bea680-d639-11e8-89c8-03831fdf3c8a.png)

Read more about Shopify's admin panel update:
https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers